### PR TITLE
PML-144: Support resuming from a failure

### DIFF
--- a/mongolink/clone.go
+++ b/mongolink/clone.go
@@ -158,6 +158,13 @@ func (c *Clone) Status() CloneStatus {
 	}
 }
 
+func (c *Clone) resetError() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.err = nil
+}
+
 func (c *Clone) Done() <-chan struct{} {
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/mongolink/mongolink.go
+++ b/mongolink/mongolink.go
@@ -324,7 +324,6 @@ func (ml *MongoLink) Start(_ context.Context, options *StartOptions) error {
 	ml.state = StateRunning
 
 	go ml.run()
-	go ml.onStateChanged(StateRunning)
 
 	return nil
 }

--- a/mongolink/repl.go
+++ b/mongolink/repl.go
@@ -177,6 +177,13 @@ func (r *Repl) Status() ReplStatus {
 	}
 }
 
+func (r *Repl) resetError() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.err = nil
+}
+
 func (r *Repl) Done() <-chan struct{} {
 	r.lock.Lock()
 	defer r.lock.Unlock()


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PML-144

**Problem**
In a  case where something happens to target cluster, like a primary restart or step down during repliccatioon, a certain operations can fail to perform and PML will stop (pause) replication and report a failure. In this case, after target cluster gets healed, there is no way to resume replication and the only thing is to restart PML.

**Solution**
Provide the ability to perform `resume` in this case. Now a user can do `percona-mongolink resume --from-failure`. When this happens PML will reset ML, repl and clone error and resume replication.

---
PR also fixes https://perconadev.atlassian.net/browse/PML-145