### PR TITLE
PML-154: IntitialSync.completed status flips

### DIFF
--- a/.github/workflows/e2etests.yml
+++ b/.github/workflows/e2etests.yml
@@ -1,11 +1,7 @@
 # .github/workflows/e2e-tests.yml
 name: E2E Tests
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+on: [pull_request]
 
 jobs:
   rs:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,9 +1,6 @@
 name: code
-on:
-  push:
-    branches: ["main"]
-  pull_request:
-    branches: ["main"]
+
+on: [pull_request]
 
 jobs:
   test:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,5 +1,7 @@
 name: reviewdog
+
 on: [pull_request]
+
 jobs:
   misspell:
     name: misspell

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,9 +1,7 @@
 name: Scan
-on:
-  push:
-    branches: ["main"]
-  pull_request:
-    branches: ["main"]
+
+on: [pull_request]
+
 jobs:
   scan:
     name: Trivy

--- a/mongolink/mongolink.go
+++ b/mongolink/mongolink.go
@@ -245,6 +245,12 @@ func (ml *MongoLink) Status(ctx context.Context) *Status {
 		s.Error = errors.Wrap(s.Clone.Err, "Clone")
 	}
 
+	if s.Repl.IsStarted() {
+		intialSyncLag := max(int64(s.Clone.FinishTS.T)-int64(s.Repl.LastReplicatedOpTime.T), 0)
+		s.InitialSyncLagTime = &intialSyncLag
+		s.InitialSyncCompleted = s.Repl.LastReplicatedOpTime.After(s.Clone.FinishTS)
+	}
+
 	if ml.state == StateFailed {
 		return s
 	}
@@ -265,12 +271,6 @@ func (ml *MongoLink) Status(ctx context.Context) *Status {
 	}
 
 	s.InitialSyncLagTime = s.TotalLagTime
-
-	if s.Repl.IsStarted() {
-		intialSyncLag := max(int64(s.Clone.FinishTS.T)-int64(s.Repl.LastReplicatedOpTime.T), 0)
-		s.InitialSyncLagTime = &intialSyncLag
-		s.InitialSyncCompleted = s.Repl.LastReplicatedOpTime.After(s.Clone.FinishTS)
-	}
 
 	return s
 }


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PML-154

**Problem**

In a situation where after initial sync is finished (reported in the logs and in the status) and then replication fails, in status `initialSync.completed` flips back to `false` after being `true` and after init sync actually is done.

**Solution**

In `MongoLink.Status` method we need to set inital sync status data before `ml.state == StateFailed` check.

---
PR also updates where some github actions run.