### PR TITLE
Hide recovery and heartbeat sub commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,18 @@ Example:
 
 Resumes the replication process.
 
+#### Request Body
+
+- `fromFailure` (optional): Allows PML to resume from failed state
+
+Example:
+
+```json
+{
+    "fromFailure": true
+}
+```
+
 #### Response
 
 - `ok`: Boolean indicating if the operation was successful.

--- a/main.go
+++ b/main.go
@@ -259,9 +259,9 @@ var resetCmd = &cobra.Command{
 
 //nolint:gochecknoglobals
 var resetRecoveryCmd = &cobra.Command{
-	Use:   "recovery",
+	Use:    "recovery",
 	Hidden: true,
-	Short: "Reset recovery state",
+	Short:  "Reset recovery state",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		targetURI, _ := cmd.InheritedFlags().GetString("target")
 		if targetURI == "" {
@@ -298,9 +298,9 @@ var resetRecoveryCmd = &cobra.Command{
 
 //nolint:gochecknoglobals
 var resetHeartbeatCmd = &cobra.Command{
-	Use:   "heartbeat",
+	Use:    "heartbeat",
 	Hidden: true,
-	Short: "Reset heartbeat state",
+	Short:  "Reset heartbeat state",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		targetURI, _ := cmd.InheritedFlags().GetString("target")
 		if targetURI == "" {

--- a/main.go
+++ b/main.go
@@ -260,6 +260,7 @@ var resetCmd = &cobra.Command{
 //nolint:gochecknoglobals
 var resetRecoveryCmd = &cobra.Command{
 	Use:   "recovery",
+	Hidden: true,
 	Short: "Reset recovery state",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		targetURI, _ := cmd.InheritedFlags().GetString("target")
@@ -298,6 +299,7 @@ var resetRecoveryCmd = &cobra.Command{
 //nolint:gochecknoglobals
 var resetHeartbeatCmd = &cobra.Command{
 	Use:   "heartbeat",
+	Hidden: true,
 	Short: "Reset heartbeat state",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		targetURI, _ := cmd.InheritedFlags().GetString("target")


### PR DESCRIPTION
Hide `pml reset recovery` and `pml reset heartbeat` sub commands because there is almost no use case for a user to use them separately and can potentially confuse them.

Mostly, users should use only `pml reset` that will clear both heartbeat and checkpoint data.

PR, also updates readme with missing info for `/resume` endpoint.