### PR TITLE
PML-165: Increase default client operation timeout

### DIFF
--- a/config/const.go
+++ b/config/const.go
@@ -44,6 +44,9 @@ const (
 	DisconnectTimeout = 5 * time.Second
 	// CloseCursorTimeout is the timeout duration for closing cursor.
 	CloseCursorTimeout = 10 * time.Second
+	// OperationTimeout is the timeout duration for MonngoDB client operations like
+	// insert, update, delete, etc.
+	OperationTimeout = 5 * time.Minute
 )
 
 // Change stream and replication settings.

--- a/topo/connect.go
+++ b/topo/connect.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"slices"
 	"strings"
-	"time"
 
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
@@ -59,7 +58,7 @@ func ConnectWithOptions(
 		SetReadPreference(readpref.Primary()).
 		SetReadConcern(readconcern.Majority()).
 		SetWriteConcern(writeconcern.Majority()).
-		SetTimeout(time.Minute)
+		SetTimeout(config.OperationTimeout)
 
 	if connOpts != nil && connOpts.Compressors != nil {
 		opts.SetCompressors(connOpts.Compressors)


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PML-165

Increase default MongoDB client operation timeout to 5 minutes.